### PR TITLE
Moved from travis to github actions for testing pull requests

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  create:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  test:
+    name: Unit Tests
+    runs-on: [ ubuntu-latest ]
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+      # Setup Go
+      - name: Setup Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: '1.15.x' # The Go version to download (if necessary) and use.
+
+      # Run gofmt on the code
+      - name: Run gofmt
+        run: gofmt -d
+
+      # Run unit tests for the code
+      - name: Run tests
+        run: |
+          go test -v -race ./...
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-language: go
-go: 
- - 1.14
-before_script:
-  - go get -t ./...
-script:
-  - go test -v ./...


### PR DESCRIPTION
Notable changes:
- Increased the go version from 1.14 to 1.15
- Added a `gofmt` check.  If we don't like this, it's easy to remove. 🙂 
- Added the `-race` flag for unit testing

A potential place for improvement would be to update the [Makefile `test` target](https://github.com/Comcast/sheens/blob/5eed25b08c1df211de111ae033386fea87ded3ce/Makefile#L9) to reflect the test command we want run in automation.  Then the github action can call `make test` instead of a go command directly.