### PR TITLE
added a few spec tests, enumerated some defaults

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -29,5 +29,5 @@ jobs:
       # Run unit tests for the code
       - name: Run tests
         run: |
-          go test -v -race ./...
+          go test -v ./...
 

--- a/core/spec.go
+++ b/core/spec.go
@@ -1,4 +1,4 @@
-/* Copyright 2018 Comcast Cable Communications Management, LLC
+/* Copyright 2021 Comcast Cable Communications Management, LLC
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -18,36 +18,18 @@ import (
 	"errors"
 )
 
-var (
-	// DefaultPatternParser is used during Spec.Compile if the
-	// given Spec has no PatternParser.
-	//
-	// This function is useful to allow a Spec to provide branch
-	// patterns in whatever syntax is convenient.  For example, if
-	// a Spec is authored in YAML, patterns in JSON might be more
-	// convenient (or easier to read) that patterns in YAML.
-	DefaultPatternParser = func(syntax string, p interface{}) (interface{}, error) {
-		switch syntax {
-		case "none", "":
-			return p, nil
-		case "json":
-			if js, is := p.(string); is {
-				var x interface{}
-				if err := json.Unmarshal([]byte(js), &x); err != nil {
-					return nil, err
-				}
-				return x, nil
-			}
-			return p, nil
-		default:
-			return nil, errors.New("unsupposed pattern syntax: " + syntax)
-		}
-	}
-
+const (
 	// DefaultBranchType is used for Branches.Type when
-	// Branches.Type is zero.  This var should probably be a
-	// const.
+	// Branches.Type is zero.
 	DefaultBranchType = "bindings"
+
+	// DefaultErrorNodeName is the name of the node state
+	// switched to in the event of an internal error.
+	DefaultErrorNodeName = "error"
+)
+
+var (
+	defaultErrorNode = &Node{}
 )
 
 // Spec is a specification used to build a machine.
@@ -97,7 +79,7 @@ type Spec struct {
 	Nodes map[string]*Node `json:"nodes,omitempty" yaml:",omitempty"`
 
 	// ErrorNode is an optional name of a node for the machine in
-	// the even of an internal error.
+	// the event of an internal error.
 	//
 	// Probably should just always assume the convention that a
 	// node named 'error' is the error node.  ToDo: Consider.
@@ -189,11 +171,14 @@ func (spec *Spec) ParsePatterns(ctx context.Context) error {
 	}
 
 	for _, n := range spec.Nodes {
-		if n.Branches == nil {
+		if n == nil || n.Branches == nil {
 			continue
 		}
 
 		for _, b := range n.Branches.Branches {
+			if b == nil {
+				continue
+			}
 			x, err := spec.PatternParser(spec.PatternSyntax, b.Pattern)
 			if err != nil {
 				return err
@@ -208,8 +193,9 @@ func (spec *Spec) ParsePatterns(ctx context.Context) error {
 	return nil
 }
 
-// Compile compiles all action-like sources into actions. Might also
-// do some other things.
+// Compile compiles all action-like sources into actions. Might also do some
+// other things. When force is true, everything is built from source even if
+// it's been built before.
 //
 // Action-like sources include Actions, Boot, Toob, and Guards.
 func (spec *Spec) Compile(ctx context.Context, interpreters Interpreters, force bool) error {
@@ -235,7 +221,7 @@ func (spec *Spec) Compile(ctx context.Context, interpreters Interpreters, force 
 	}
 
 	if spec.ErrorNode == "" {
-		spec.ErrorNode = "error"
+		spec.ErrorNode = DefaultErrorNodeName
 	}
 
 	if spec.Nodes == nil {
@@ -243,7 +229,7 @@ func (spec *Spec) Compile(ctx context.Context, interpreters Interpreters, force 
 	}
 
 	if _, have := spec.Nodes[spec.ErrorNode]; !have && !spec.NoAutoErrorNode {
-		spec.Nodes[spec.ErrorNode] = &Node{}
+		spec.Nodes[spec.ErrorNode] = defaultErrorNode
 	}
 
 	for name, n := range spec.Nodes {
@@ -420,5 +406,30 @@ func (b *Branch) Copy() *Branch {
 		Guard:       b.Guard,
 		GuardSource: b.GuardSource,
 		Target:      b.Target,
+	}
+}
+
+// DefaultPatternParser is used during Spec.Compile if the
+// given Spec has no PatternParser.
+//
+// This function is useful to allow a Spec to provide branch
+// patterns in whatever syntax is convenient.  For example, if
+// a Spec is authored in YAML, patterns in JSON might be more
+// convenient (or easier to read) that patterns in YAML.
+func DefaultPatternParser(syntax string, p interface{}) (interface{}, error) {
+	switch syntax {
+	case "none", "":
+		return p, nil
+	case "json":
+		if js, is := p.(string); is {
+			var x interface{}
+			if err := json.Unmarshal([]byte(js), &x); err != nil {
+				return nil, err
+			}
+			return x, nil
+		}
+		return p, nil
+	default:
+		return nil, errors.New("unsupposed pattern syntax: " + syntax)
 	}
 }

--- a/core/spec_test.go
+++ b/core/spec_test.go
@@ -1,0 +1,261 @@
+/* Copyright 2021 Comcast Cable Communications Management, LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package core
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func mockPatternParser(val interface{}, err error) func(string, interface{}) (interface{}, error) {
+	return func(_ string, _ interface{}) (interface{}, error) {
+		return val, err
+	}
+}
+
+func TestParsePatterns(t *testing.T) {
+	goodNodes := map[string]*Node{
+		"yay": {
+			Branches: &Branches{
+				Branches: []*Branch{
+					{Pattern: "something nice"},
+					{Pattern: "something else"},
+					{Pattern: "something??"},
+				},
+			},
+		},
+		"next thing": {
+			Branches: &Branches{
+				Branches: []*Branch{{Pattern: 5}},
+			},
+		},
+	}
+	emptyNodes := map[string]*Node{
+		"nowhere": {},
+		"a little further": {
+			Branches: &Branches{},
+		},
+		"getting there": {
+			Branches: &Branches{
+				Branches: []*Branch{
+					nil,
+					nil,
+					{Pattern: nil},
+				},
+			},
+		},
+	}
+	testErr := errors.New("test parser error")
+	tests := []struct {
+		description   string
+		parser        func(string, interface{}) (interface{}, error)
+		nodes         map[string]*Node
+		expectedNodes map[string]*Node
+		expectedErr   error
+	}{
+		{
+			description: "Success",
+			parser:      mockPatternParser("a", nil),
+			nodes:       goodNodes,
+			expectedNodes: map[string]*Node{
+				"yay": {
+					Branches: &Branches{
+						Branches: []*Branch{{Pattern: "a"},
+							{Pattern: "a"}, {Pattern: "a"},
+						},
+					},
+				},
+				"next thing": {
+					Branches: &Branches{
+						Branches: []*Branch{{Pattern: "a"}},
+					},
+				},
+			},
+		},
+		{
+			description:   "Success with default parser",
+			nodes:         goodNodes,
+			expectedNodes: goodNodes,
+		},
+		{
+			description: "Success with no nodes",
+			parser:      mockPatternParser("c", nil),
+		},
+		{
+			description:   "Success with no branches",
+			parser:        mockPatternParser("d", nil),
+			nodes:         emptyNodes,
+			expectedNodes: emptyNodes,
+		},
+		{
+			description: "Parse failure",
+			parser:      mockPatternParser("e", testErr),
+			nodes:       goodNodes,
+			expectedErr: testErr,
+		},
+		{
+			description: "Canonicalize failure",
+			parser:      mockPatternParser([]interface{}{func() string { return ":(" }}, nil),
+			nodes:       goodNodes,
+			expectedErr: errors.New("unsupported type"),
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.description, func(t *testing.T) {
+			s := &Spec{
+				PatternParser: tc.parser,
+				Nodes:         tc.nodes,
+			}
+			err := s.ParsePatterns(context.Background())
+			if s.PatternParser == nil {
+				t.Error("pattern parser shouldn't be nil")
+			}
+
+			if err == nil || tc.expectedErr == nil {
+				if err != tc.expectedErr {
+					t.Errorf("expected %v error but received %v",
+						tc.expectedErr, err)
+				}
+			} else if !strings.Contains(err.Error(), tc.expectedErr.Error()) {
+				t.Errorf("error %s doesn't include expected string %s",
+					err, tc.expectedErr)
+			}
+
+			// if we expected an error, leave before the nightmare begins.
+			if tc.expectedErr != nil {
+				return
+			}
+
+			// start checking nodes' branches' patterns...
+			if len(tc.expectedNodes) != len(s.Nodes) {
+				t.Fatalf("nodes don't match; expected %v but received %v",
+					tc.expectedNodes, s.Nodes)
+			}
+			for k, n := range tc.expectedNodes {
+				if n == nil {
+					if s.Nodes[k] != nil {
+						t.Fatalf("nodes don't match; expected %v but received %v",
+							tc.expectedNodes, s.Nodes)
+					}
+					continue
+				}
+				if n.Branches == nil {
+					if s.Nodes[k].Branches != nil {
+						t.Fatalf("nodes don't match; expected %v but received %v",
+							tc.expectedNodes, s.Nodes)
+					}
+					continue
+				}
+				if s.Nodes[k] == nil || s.Nodes[k].Branches == nil {
+					t.Fatalf("nodes don't match; expected %v but received %v",
+						tc.expectedNodes, s.Nodes)
+				}
+				expectedBranches := n.Branches.Branches
+				sBranches := s.Nodes[k].Branches.Branches
+				if len(expectedBranches) != len(sBranches) {
+					t.Fatalf("nodes don't match; expected %v but received %v",
+						tc.expectedNodes, s.Nodes)
+				}
+				for j, b := range expectedBranches {
+					if b == nil {
+						if sBranches[j] != nil {
+							t.Fatalf("nodes don't match; expected %v but received %v",
+								tc.expectedNodes, s.Nodes)
+						}
+						continue
+					}
+					if sBranches[j] == nil {
+						t.Fatalf("nodes don't match; expected %v but received %v",
+							tc.expectedNodes, s.Nodes)
+					}
+					if b.Pattern != sBranches[j].Pattern {
+						t.Fatalf("nodes don't match; expected %v but received %v",
+							tc.expectedNodes, s.Nodes)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestCompile(t *testing.T) {
+	s := &Spec{}
+	err := s.Compile(context.Background(), nil, false)
+	if err != nil {
+		t.Fatalf("expected no error but received %v", err)
+	}
+}
+
+func TestDefaultPatternParser(t *testing.T) {
+	tests := []struct {
+		description    string
+		syntax         string
+		val            interface{}
+		expectedResult interface{}
+		expectedErr    error
+	}{
+		{
+			description: "Default error",
+			syntax:      "clearly invalid",
+			val:         "testing123",
+			expectedErr: errors.New("unsupposed pattern syntax"),
+		},
+		{
+			description:    "None syntax success",
+			syntax:         "none",
+			val:            struct{}{},
+			expectedResult: struct{}{},
+		},
+		{
+			description: "Empty syntax success",
+		},
+		{
+			description:    "JSON syntax success",
+			syntax:         "json",
+			val:            `"test"`,
+			expectedResult: "test",
+		},
+		{
+			description: "JSON syntax non-string success",
+			syntax:      "json",
+		},
+		{
+			description: "JSON unmarshal error",
+			syntax:      "json",
+			val:         "",
+			expectedErr: errors.New("unexpected end of JSON input"),
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.description, func(t *testing.T) {
+			r, err := DefaultPatternParser(tc.syntax, tc.val)
+			if tc.expectedResult != r {
+				t.Errorf("expected %v pattern but received %v",
+					tc.expectedResult, r)
+			}
+			if err == nil || tc.expectedErr == nil {
+				if err != tc.expectedErr {
+					t.Errorf("expected %v error but received %v",
+						tc.expectedErr, err)
+				}
+				return
+			}
+			if !strings.Contains(err.Error(), tc.expectedErr.Error()) {
+				t.Errorf("error %s doesn't include expected string %s",
+					err, tc.expectedErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
- Added some unit tests...didn't get as far as I wanted because of the intricacies of nil.
- Changed `DefaultPatternParser` so it cannot be reassigned.  This is backwards compatible. 🙂 
- Made some const defaults.  No functionality changed.  Technically, if a consumer was reassigning `DefaultBranchType`, this is a breaking change.
- Added some nil checks in `ParsePatterns()`.